### PR TITLE
feat: set `split-divider-color` option

### DIFF
--- a/ghostty.tera
+++ b/ghostty.tera
@@ -27,3 +27,4 @@ cursor-color = {{ rosewater.hex }}
 cursor-text = {{ if(cond=flavor.light, t=base.hex, f=crust.hex) }}
 selection-background = {{ overlay2 | mix(color=base, amount=0.2) | get(key="hex") }}
 selection-foreground = {{ text.hex }}
+split-divider-color = {{ surface0.hex }}

--- a/themes/catppuccin-frappe.conf
+++ b/themes/catppuccin-frappe.conf
@@ -20,3 +20,4 @@ cursor-color = f2d5cf
 cursor-text = 232634
 selection-background = 44495d
 selection-foreground = c6d0f5
+split-divider-color = 414559

--- a/themes/catppuccin-latte.conf
+++ b/themes/catppuccin-latte.conf
@@ -20,3 +20,4 @@ cursor-color = dc8a78
 cursor-text = eff1f5
 selection-background = d8dae1
 selection-foreground = 4c4f69
+split-divider-color = ccd0da

--- a/themes/catppuccin-macchiato.conf
+++ b/themes/catppuccin-macchiato.conf
@@ -20,3 +20,4 @@ cursor-color = f4dbd6
 cursor-text = 181926
 selection-background = 3a3e53
 selection-foreground = cad3f5
+split-divider-color = 363a4f

--- a/themes/catppuccin-mocha.conf
+++ b/themes/catppuccin-mocha.conf
@@ -20,3 +20,4 @@ cursor-color = f5e0dc
 cursor-text = 11111b
 selection-background = 353749
 selection-foreground = cdd6f4
+split-divider-color = 313244


### PR DESCRIPTION
By default, Ghostty uses a dark gray divider for splits, which is hard to see in dark theme variants and doesn't match the color palette. This change sets the divider color to `lavender`, following the [Catppuccin Kitty](https://github.com/catppuccin/kitty/blob/b14e8385c827f2d41660b71c7fec1e92bdcf2676/templates/kitty.tera#L32) for consistency.

### Before/After

<details>
<summary>Mocha</summary>
<img width="725" height="725" alt="1760610664_screenshot" src="https://github.com/user-attachments/assets/4a6e3125-954f-4836-ae42-55da4aca94ad" />
<img width="725" height="725" alt="1760610678_screenshot" src="https://github.com/user-attachments/assets/bb8f2d1f-35b1-4a06-819f-d1b195a07a8d" />
</details>

<details>
<summary>Latte</summary>
<img width="725" height="725" alt="1760619533_screenshot" src="https://github.com/user-attachments/assets/484d9dc0-d4d0-4ed0-8900-cc0c3e8a34c7" />
<img width="725" height="725" alt="1760619543_screenshot" src="https://github.com/user-attachments/assets/396e14a5-aea7-427e-b0ed-4d582254eb9a" />
</details>