### PR TITLE
change theme names to ghostty 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 ## Usage
 
-Set `theme = catppuccin-<flavor>` in your [Ghostty configuration file](https://ghostty.org/docs/config#file-location), where `<flavor>` is one of `latte`, `frappe`, `macchiato`, or `mocha`.
+Set `theme = Catppuccin <flavor>` in your [Ghostty configuration file](https://ghostty.org/docs/config#file-location), where `<flavor>` is one of `Latte`, `Frappe`, `Macchiato`, or `Mocha`.
 
 ### Direct/Manually
 


### PR DESCRIPTION
The current usage instruction gives an error for latest Ghostty version since these theme names were [changed in 1.2.0](https://ghostty.org/docs/install/release-notes/1-2-0#breaking-changes). 

Change to the new names that were fetched from the upstream theme repository for 1.2.0. We can see the current names here:

```shell
$ ghostty +list-themes | grep -i catppuccin
Catppuccin Frappe (resources)
Catppuccin Latte (resources)
Catppuccin Macchiato (resources)
Catppuccin Mocha (resources)
```